### PR TITLE
Fix: Unauthorized error on sign in

### DIFF
--- a/app/[locale]/(admin)/layout.tsx
+++ b/app/[locale]/(admin)/layout.tsx
@@ -1,14 +1,17 @@
 import ResponsiveContainer from '~/components/layout/ResponsiveContainer';
-import LanguageSwitcher from '../_components/LanguageSwitcher';
+import MainNavigation from '../_components/MainNavigation';
+import { getServerSession } from '~/lib/auth';
 
-export default function AdminLayout({
+export default async function AdminLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const { session } = await getServerSession();
+
   return (
     <ResponsiveContainer>
-      <LanguageSwitcher />
+      <MainNavigation showStudySwitcher={!!session} />
       {children}
     </ResponsiveContainer>
   );

--- a/app/[locale]/_components/MainNavigation.tsx
+++ b/app/[locale]/_components/MainNavigation.tsx
@@ -5,14 +5,18 @@ import { routes } from '~/lib/routes';
 import SignOutBtn from './SignOutBtn';
 import StudySwitcher from './StudySwitcher';
 
-export default function MainNavigation() {
+export default function MainNavigation({
+  showStudySwitcher,
+}: {
+  showStudySwitcher?: boolean;
+}) {
   const t = useTranslations('MainNavigation');
   return (
     <nav className="sticky top-0 flex w-full items-center justify-between gap-4 bg-slate-blue-dark p-2">
       <Link href={routes.home()} className="text-white">
         {t('home')}
       </Link>
-      <StudySwitcher />
+      {showStudySwitcher && <StudySwitcher />}
       <LanguageSwitcher />
       <SignOutBtn />
     </nav>

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -2,7 +2,6 @@ import { NextIntlClientProvider } from 'next-intl';
 import { Inter } from 'next/font/google';
 import { getMessages } from 'next-intl/server';
 import { type Metadata } from 'next';
-import MainNavigation from './_components/MainNavigation';
 import '~/app/globals.scss';
 import { SUPPORTED_LOCALES, type Locale } from '~/lib/localisation/locales';
 import { Analytics } from '@vercel/analytics/react';
@@ -36,10 +35,7 @@ export default async function RootLayout({
       <body className={inter.className}>
         <NextIntlClientProvider messages={messages}>
           <RadixDirectionProvider dir={dir}>
-            <TooltipProvider>
-              <MainNavigation />
-              {children}
-            </TooltipProvider>
+            <TooltipProvider>{children}</TooltipProvider>
           </RadixDirectionProvider>
         </NextIntlClientProvider>
         <Analytics />


### PR DESCRIPTION
Sign in page was throwing an unauthorized error. This was because `StudySwitcher` requires `session` and is part of `MainNavigation`. This PR uses the `session` to conditionally render the `StudySwitcher` using a `showStudySwitcher` prop.  
