### PR TITLE
simplify the types for the dialog system

### DIFF
--- a/components/interview/ui/HelpButton.tsx
+++ b/components/interview/ui/HelpButton.tsx
@@ -15,7 +15,7 @@ import Form from '~/components/ui/form/Form';
  * This popover allows the participant to trigger help wizards.
  */
 export default function HelpButton({ id }: { id?: string }) {
-  const { openCustomDialog } = useDialog();
+  const { openDialog } = useDialog();
   const { wizards, setActiveWizard } = useWizardController();
 
   const t = useTranslations('Interview.Navigation');
@@ -24,7 +24,8 @@ export default function HelpButton({ id }: { id?: string }) {
 
   const handleOpenDialog = async () => {
     // Return type should be string | null
-    const result = await openCustomDialog<string>({
+    const result = await openDialog<string>({
+      type: 'custom',
       id: 'help-dialog',
       title: t2('Title'),
       description: t2('Description'),

--- a/components/layout/Surface.tsx
+++ b/components/layout/Surface.tsx
@@ -3,7 +3,7 @@
 import { type Ref, type ElementType, type ReactNode } from 'react';
 import { tv, type VariantProps } from 'tailwind-variants';
 import { cn } from '~/lib/utils';
-import { motion, MotionProps } from 'framer-motion';
+import { motion, type MotionProps } from 'framer-motion';
 
 export const surfaceVariants = tv({
   base: 'shadow',

--- a/lib/dialogs/Dialog.tsx
+++ b/lib/dialogs/Dialog.tsx
@@ -11,7 +11,6 @@ export type DialogProps = {
   ref?: React.RefObject<HTMLDialogElement>;
   accent?: 'default' | 'danger' | 'success' | 'warning' | 'info';
   closeDialog: () => void;
-  childrenWithRenderProp?: (closeDialog: () => void) => React.ReactNode;
 } & React.DialogHTMLAttributes<HTMLDialogElement>;
 
 /**
@@ -62,7 +61,7 @@ export const Dialog = ({
         className={cn(
           'max-w-4xl rounded bg-surface-0 text-surface-0-foreground',
 
-          // Accent
+          // Accent overrides the primary hue so that nested buttons inherit color
           accent === 'success' && '[--primary:var(--success)]',
           accent === 'warning' && '[--primary:var(--warning)]',
           accent === 'info' && '[--primary:var(--info)]',

--- a/lib/dialogs/useDialog.stories.tsx
+++ b/lib/dialogs/useDialog.stories.tsx
@@ -36,14 +36,17 @@ type Story = StoryObj<typeof meta>;
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 export const Default: Story = {
   render: () => {
-    const { openDialog, openCustomDialog } = useDialog();
+    const { openDialog } = useDialog();
 
     const confirmDialog = async () => {
       // Return type should be boolean | null
       const result = await openDialog({
-        id: 'confirm-dialog',
-        title: 'Are you sure?',
-        description: 'This action cannot be undone.',
+        type: 'confirm',
+        title: 'Confirm dialog title',
+        description:
+          'confirm dialog description, which is read by screen readers',
+        cancelText: 'Custom cancel text',
+        confirmText: 'Custom confirm text',
       });
 
       console.log('got result', result);
@@ -51,14 +54,15 @@ export const Default: Story = {
 
     const customDialog = async () => {
       // Return type should be inferred as string | null
-      const result = await openCustomDialog<string>({
-        id: 'custom-dialog',
+      const result = await openDialog<string>({
+        type: 'custom',
         title: 'Custom Dialog',
         description: 'This is a custom dialog',
         // 'resolve' should be inferred as (value: string | null) => void
         renderContent: (resolve) => {
           const handleConfirm = async () => {
             const confirmed = await openDialog({
+              type: 'confirm',
               title: 'Are you really sure?',
               accent: 'danger',
               description: 'This action cannot be undone.',


### PR DESCRIPTION
Small PR that improves the API of the useDialog hook to only require a single open method, where the type property allows for discriminated union in the implementation to correctly infer other properties (as well as return type).